### PR TITLE
feat: track active apps and chrome tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Using Electron to build a time tracker.
 
 ## Development
 
-1. Install dependencies:
+1. Install dependencies (this will also rebuild native modules for Electron):
    ```bash
    npm install
    ```

--- a/implementation.md
+++ b/implementation.md
@@ -16,6 +16,7 @@
 - [x] Configure SQLite database and ORM
 - [x] Create initial `data/categorization.csv` seed file
 - [x] Set up linting, formatting, and basic test harness
+- [x] Add `electron-rebuild` to ensure native modules match Electron
 
 ## Phase 3: Activity Tracking
  - [x] Implement macOS foreground application tracking

--- a/implementation.md
+++ b/implementation.md
@@ -9,7 +9,7 @@
 - [x] Add third round of clarification questions
 - [x] Receive answers to third round of questions
 - [x] Add fourth round of clarification questions
-- [ ] Receive answers to fourth round of questions
+ - [x] Receive answers to fourth round of questions
 
 ## Phase 2: Project Setup
 - [x] Initialize Electron project structure
@@ -18,10 +18,10 @@
 - [x] Set up linting, formatting, and basic test harness
 
 ## Phase 3: Activity Tracking
-- [ ] Implement macOS foreground application tracking
-- [ ] Implement Chrome tab tracking (including incognito)
-- [ ] Pause and label tracking as idle on screen lock or sleep
-- [ ] Persist activity logs to SQLite rounding to 10-second granularity
+ - [x] Implement macOS foreground application tracking
+ - [x] Implement Chrome tab tracking (including incognito)
+ - [ ] Pause and label tracking as idle on screen lock or sleep
+ - [x] Persist activity logs to SQLite rounding to 10-second granularity
 
 ## Phase 4: Categorization
 - [ ] Load default categories from CSV into SQLite

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "type": "commonjs",
   "dependencies": {
     "electron": "^30.0.0",
-    "better-sqlite3": "^9.0.0"
+    "better-sqlite3": "^9.0.0",
+    "active-win": "^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,16 @@
     "start": "electron .",
     "test": "node --test",
     "lint": "echo \"Linting not configured\"",
-    "format": "echo \"Formatting not configured\""
+    "format": "echo \"Formatting not configured\"",
+    "postinstall": "electron-rebuild"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "devDependencies": {
+    "electron-rebuild": "^3.2.19"
+  },
   "dependencies": {
     "electron": "^30.0.0",
     "better-sqlite3": "^9.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
+const { startTracking } = require('./tracker');
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -13,7 +14,10 @@ function createWindow() {
   win.loadFile(path.join(__dirname, 'index.html'));
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  createWindow();
+  startTracking();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -1,0 +1,50 @@
+const activeWin = require('active-win');
+const { exec } = require('child_process');
+const db = require('./db');
+
+async function getChromeActiveTab() {
+  return new Promise((resolve) => {
+    const script = 'tell application "Google Chrome" to if (count of windows) > 0 then tell front window to get URL of active tab';
+    exec(`osascript -e '${script}'`, (err, stdout) => {
+      if (err) return resolve(null);
+      resolve(stdout.trim());
+    });
+  });
+}
+
+let current = null;
+
+async function pollActivity() {
+  try {
+    const win = await activeWin();
+    if (!win) return;
+    let activity;
+    if (win.owner.name === 'Google Chrome') {
+      const url = await getChromeActiveTab();
+      if (!url) return;
+      activity = { type: 'website', identifier: url };
+    } else {
+      const identifier = win.owner.bundleId || win.owner.name;
+      activity = { type: 'app', identifier };
+    }
+    const now = Date.now();
+    if (current && current.identifier === activity.identifier && current.type === activity.type) {
+      return;
+    }
+    if (current) {
+      const start = Math.round(current.startTime / 10000) * 10000;
+      const end = Math.round(now / 10000) * 10000;
+      db.prepare('INSERT INTO activities (type, identifier, start_time, end_time) VALUES (?, ?, ?, ?)')
+        .run(current.type, current.identifier, start, end);
+    }
+    current = { ...activity, startTime: now };
+  } catch (e) {
+    // ignore errors to keep polling
+  }
+}
+
+function startTracking() {
+  setInterval(pollActivity, 5000);
+}
+
+module.exports = { startTracking };


### PR DESCRIPTION
## Summary
- add `active-win` dependency for capturing foreground application
- implement tracker to log active apps and Chrome tabs every 5 seconds and persist to SQLite
- hook tracking startup into Electron main process and update plan

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68be077a0a08832caa319e909e78c935