### PR TITLE
Fix better-sqlite3 mismatch by rebuilding native modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Using Electron to build a time tracker.
 
 ## Development
 
-1. Install dependencies:
+1. Install dependencies (this will also rebuild native modules for Electron):
    ```bash
    npm install
    ```

--- a/implementation.md
+++ b/implementation.md
@@ -16,6 +16,7 @@
 - [x] Configure SQLite database and ORM
 - [x] Create initial `data/categorization.csv` seed file
 - [x] Set up linting, formatting, and basic test harness
+- [x] Add `electron-rebuild` to ensure native modules match Electron
 
 ## Phase 3: Activity Tracking
  - [x] Implement macOS foreground application tracking

--- a/package.json
+++ b/package.json
@@ -7,12 +7,16 @@
     "start": "electron .",
     "test": "node --test",
     "lint": "echo \"Linting not configured\"",
-    "format": "echo \"Formatting not configured\""
+    "format": "echo \"Formatting not configured\"",
+    "postinstall": "electron-rebuild"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "devDependencies": {
+    "electron-rebuild": "^3.2.19"
+  },
   "dependencies": {
     "electron": "^30.0.0",
     "better-sqlite3": "^9.0.0",


### PR DESCRIPTION
## Summary
- ensure native modules like better-sqlite3 are rebuilt for the Electron runtime
- document the rebuild step in development instructions
- record progress in implementation plan

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/active-win)*
- `npx electron -e "require('better-sqlite3')"` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8e58d458832cbaf7c37f5b18c35b